### PR TITLE
Get rid of hero tags and simplify HTML

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,6 @@
       <i class="fab fa-creative-commons-nc fa-{{ include.icon-size }}" aria-hidden="true"></i>
       <i class="fab fa-creative-commons-sa fa-{{ include.icon-size }}" aria-hidden="true"></i>
     </a>
-    Creative Commons License CC BY-NC-SA 4.0
+    Creative Commons License <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a>
   </div>
 </footer>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,29 +1,13 @@
-<div class="hero-foot">
-  <footer class="footer">
-    <div class="container">
-      <div class="content has-text-centered is-size-7">
-        <p>
-        Template created by Alex Hernandez-Garcia, based on 
-        <a href="https://alexhernandezgarcia.github.io/">alexhernandezgarcia.github.io</a>.
-        The code relies on 
-        <a href="https://jekyllrb.com/">jekyll</a>
-        and 
-        <a href="https://bulma.io/">bulma</a>.
-        You are welcome to fork 
-        <a href="https://github.com/alexhernandezgarcia/template-personal-website">the repository of this template</a>
-        or 
-        <a href="https://github.com/alexhernandezgarcia/alexhernandezgarcia.github.io">the original one</a>
-        to create your own website.<br>
-        Creative Commons License 
-        <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-          <i class="fab fa-creative-commons fa-{{ include.icon-size }}" aria-hidden="true"></i>
-          <i class="fab fa-creative-commons-by fa-{{ include.icon-size }}" aria-hidden="true"></i>
-          <i class="fab fa-creative-commons-nc fa-{{ include.icon-size }}" aria-hidden="true"></i>
-          <i class="fab fa-creative-commons-sa fa-{{ include.icon-size }}" aria-hidden="true"></i>
-        </a>
-        </p>
-      </div>
-    </div>
-  </footer>
-</div>
-
+<footer class="footer">
+  <div class="content has-text-centered is-size-7">
+    {% capture content %}{% include footer.md %}{% endcapture %}
+    {{ content | markdownify }}
+    <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
+      <i class="fab fa-creative-commons fa-{{ include.icon-size }}" aria-hidden="true"></i>
+      <i class="fab fa-creative-commons-by fa-{{ include.icon-size }}" aria-hidden="true"></i>
+      <i class="fab fa-creative-commons-nc fa-{{ include.icon-size }}" aria-hidden="true"></i>
+      <i class="fab fa-creative-commons-sa fa-{{ include.icon-size }}" aria-hidden="true"></i>
+    </a>
+    Creative Commons License CC BY-NC-SA 4.0
+  </div>
+</footer>

--- a/_includes/footer.md
+++ b/_includes/footer.md
@@ -1,0 +1,4 @@
+Template created by Alex Hernandez-Garcia, based on [alexhernandezgarcia.github.io](https://alexhernandezgarcia.github.io/).
+The code relies on [jekyll](https://jekyllrb.com/) and [bulma](https://bulma.io/).
+You are welcome to fork [the repository of this template](https://github.com/alexhernandezgarcia/template-personal-website) or [the original one](https://github.com/alexhernandezgarcia/alexhernandezgarcia.github.io/) to create your own website.
+

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,37 +1,35 @@
-<div class="hero-head">
-  <nav class="navbar container" role=navigation>
-    <div class="navbar-brand">
-      <a class="navbar-item" href="/">
-        <strong>{{ site.title }}</strong>
-      </a>
-	    <div role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar-main">
-  		  <span aria-hidden="true"></span>
-    		<span aria-hidden="true"></span>
-    		<span aria-hidden="true"></span>
-  	  </div>
+<nav class="navbar container" role=navigation>
+  <div class="navbar-brand">
+    <a class="navbar-item" href="/">
+      <strong>{{ site.title }}</strong>
+    </a>
+    <div role="button" class="navbar-burger burger" aria-label="menu" aria-expanded="false" data-target="navbar-main">
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
     </div>
-    <div id="navbar-main" class="navbar-menu">
-      <div class="navbar-start">
-        {% for item in site.data.navigation %}
-          <a class="navbar-item" href="{{ item.link }}" {% if page.url == item.link %}class="is-dark"{% endif %}>
-            {{ item.name }}
+  </div>
+  <div id="navbar-main" class="navbar-menu">
+    <div class="navbar-start">
+      {% for item in site.data.navigation %}
+        <a class="navbar-item" href="{{ item.link }}" {% if page.url == item.link %}class="is-dark"{% endif %}>
+          {{ item.name }}
+        </a>
+      {% endfor %}
+    </div>
+    <div class="navbar-end">
+      <div class="navbar-item">
+        {% for item in site.data.social %}
+          <a class="button is-text" href="{{ item.link }}" style="text-decoration: none">
+            <span class="icon">
+              <i
+                class="{{ item.icon.type }} {{ item.icon.name }} {{ item.icon.source }}-{{ include.icon-size }}"
+                aria-hidden="true">
+              </i>
+            </span>
           </a>
         {% endfor %}
       </div>
-      <div class="navbar-end">
-    		<div class="navbar-item">
-    		  {% for item in site.data.social %}
-            <a class="button is-text" href="{{ item.link }}" style="text-decoration: none">
-              <span class="icon">
-                <i
-                  class="{{ item.icon.type }} {{ item.icon.name }} {{ item.icon.source }}-{{ include.icon-size }}"
-                  aria-hidden="true">
-                </i>
-              </span>
-            </a>
-    		  {% endfor %}
-    		</div>
-      </div>
     </div>
-  </nav>
-</div>
+  </div>
+</nav>

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -19,14 +19,12 @@
     {% seo %}
   </head>
   <body>
-    <section class="hero is-fullheight">
-      {% include navigation.html icon-size="lg" %}
-      <div class="hero-body">
-        <div class="container">
-          {{ content }}
-        </div>
+    {% include navigation.html icon-size="lg" %}
+    <section class="section">
+      <div class="container">
+        {{ content }}
       </div>
-      {% include footer.html icon-size="lg" %}
     </section>
+    {% include footer.html icon-size="lg" %}
   </body>
 </html>


### PR DESCRIPTION
This PR simplifies the HTML code to makes it more readable and adaptable.

It gets rid of the use of [`hero`](https://bulma.io/documentation/layout/hero/) tags, which are not really necessary because the hero banner is not truly use here. A very similar or identical appearance is achieved without it.

The markdown file `./_includes/footer.md` is also introduced here to contain the content of the footer in a markdown file instead of directly in the HTML `./_includes/footer.html`. This way it is also easier to update when needed. The create commons license is kept under the HTML file in order to make it higher priority.   